### PR TITLE
Extend client to combine offers

### DIFF
--- a/mesoshttp/client.py
+++ b/mesoshttp/client.py
@@ -713,3 +713,67 @@ class MesosClient(object):
                 if line[count_bytes:]:
                     count_bytes = int(line[count_bytes:])
         return True
+
+    def combine_offers(self, offers, operations, options=None):
+        '''
+        Accept offers with task operations
+
+        :param offers: offers to be accepted
+        :type offers: list
+        :param operations: JSON TaskInfo instances to accept
+        :type operations: list of json TaskInfo
+        :param options: optional filters
+        :type options: JSON filters instances
+        '''
+        if not operations:
+            self.logger.debug('Mesos:Accept:no operation to accept')
+            return True
+
+        if not offers:
+            self.logger.debug('Mesos:Accept:no offers to accept')
+            return True
+
+        ids = [o.get_offer()['id']['value'] for o in offers]
+        offer_ids = [{'value': oid} for oid in ids]
+        self.logger.debug('Mesos:COMBINE Offer ids:' + ','.join(ids))
+
+        headers = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'Mesos-Stream-Id': self.streamId
+        }
+
+        tasks = []
+        for operation in operations:
+            if 'agent_id' not in operation:
+                operation['agent_id'] = {
+                    'value': self.offer[0]['agent_id']['value']
+                }
+            tasks.append(operation)
+
+        message = {
+            "framework_id": {"value": self.frameworkId},
+            "type": "ACCEPT",
+            "accept": {
+                "offer_ids": offer_ids,
+                "operations": [{
+                    'type': 'LAUNCH',
+                    'launch': {'task_infos': tasks}
+                }]
+            }
+        }
+        if options and options.get('filters'):
+            message["accept"]["filters"] = options.get('filters')
+
+        message = json.dumps(message)
+        try:
+            r = requests.post(
+                self.mesos_url + '/api/v1/scheduler',
+                message,
+                headers=headers
+            )
+            self.logger.debug('Mesos:Accept:' + str(message))
+            self.logger.debug('Mesos:Accept:Anwser:%d:%s' % (r.status_code, r.text))
+        except Exception as e:
+            raise MesosException(e)
+        return True

--- a/mesoshttp/client.py
+++ b/mesoshttp/client.py
@@ -724,6 +724,9 @@ class MesosClient(object):
         :type operations: list of json TaskInfo
         :param options: optional filters
         :type options: JSON filters instances
+
+        This method does not check if the operations are valid
+        JSON TaskInfo instances and if conform with the offers.
         '''
         if not operations:
             self.logger.debug('Mesos:Accept:no operation to accept')
@@ -743,14 +746,6 @@ class MesosClient(object):
             'Mesos-Stream-Id': self.streamId
         }
 
-        tasks = []
-        for operation in operations:
-            if 'agent_id' not in operation:
-                operation['agent_id'] = {
-                    'value': ids[0]
-                }
-            tasks.append(operation)
-
         message = {
             "framework_id": {"value": self.frameworkId},
             "type": "ACCEPT",
@@ -758,7 +753,7 @@ class MesosClient(object):
                 "offer_ids": offer_ids,
                 "operations": [{
                     'type': 'LAUNCH',
-                    'launch': {'task_infos': tasks}
+                    'launch': {'task_infos': operations}
                 }]
             }
         }

--- a/mesoshttp/client.py
+++ b/mesoshttp/client.py
@@ -747,7 +747,7 @@ class MesosClient(object):
         for operation in operations:
             if 'agent_id' not in operation:
                 operation['agent_id'] = {
-                    'value': self.offer[0]['agent_id']['value']
+                    'value': ids[0]
                 }
             tasks.append(operation)
 


### PR DESCRIPTION
This commit introduces a new client method which combines multiple
offers in one ACCEPT request.
This is useful for facing the agent resource fragmentation.